### PR TITLE
일정 생성 시 참가 인원 초과 예외 처리 로직 추가

### DIFF
--- a/src/main/java/com/momo/momopjt/schedule/ScheduleController.java
+++ b/src/main/java/com/momo/momopjt/schedule/ScheduleController.java
@@ -102,15 +102,19 @@ public class ScheduleController {
 
     try {
       Long scheduleNo = scheduleService.createSchedule(scheduleDTO, userAndScheduleDTO);
-      log.info("------------ [일정 등록 완료] ------------");
+      log.info("------------ [Succeed to set schedule] ------------");
       return "redirect:/schedule/" + scheduleNo;
     } catch (ScheduleService.ScheduleDateException e) {
-      log.trace("------------ [Failed to set schedule date] ------------");
+      log.trace("------------ [Failed to set schedule: Attempted to set time in the past] ------------");
       redirectAttributes.addFlashAttribute("message", "현재 시간보다 과거의 시간을 설정할 수 없습니다.");
       return "redirect:/schedule/create";
-    } catch (ScheduleService.ScheduleMaxException e) {
-      log.trace("------------ [Failed to set schedule max] ------------");
-      redirectAttributes.addFlashAttribute("message", "참가 인원수는 0보다 적게 설정할 수 없습니다.");
+    } catch (ScheduleService.MinimumParticipantNotMetException e) {
+      log.trace("------------ [Failed to set schedule: Minimum participant not met] ------------");
+      redirectAttributes.addFlashAttribute("message", "일정 참가 인원은 최소 1명 이상이어야 합니다.");
+      return "redirect:/schedule/create";
+    } catch (ScheduleService.ScheduleParticipantLimitExceededException e) {
+      log.trace("------------ [Failed to set schedule: Participant count exceeds total club members] ------------");
+      redirectAttributes.addFlashAttribute("message", "일정 참가 인원은 모임 전체 회원 수을 초과할 수 없습니다.");
       return "redirect:/schedule/create";
     }
   }

--- a/src/main/java/com/momo/momopjt/schedule/ScheduleService.java
+++ b/src/main/java/com/momo/momopjt/schedule/ScheduleService.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 public interface ScheduleService {
 
-   Long createSchedule(ScheduleDTO scheduleDTO, UserAndScheduleDTO userAndScheduleDTO) throws ScheduleMaxException, ScheduleDateException;
+   Long createSchedule(ScheduleDTO scheduleDTO, UserAndScheduleDTO userAndScheduleDTO) throws MinimumParticipantNotMetException, ScheduleDateException, ScheduleParticipantLimitExceededException;
 
    ScheduleDTO readOneSchedule(Long scheduleNo);
 
@@ -28,7 +28,11 @@ public interface ScheduleService {
 
    List<ScheduleDTO> readMyParticipatedSchedules(Club clubNo, User userNo);
 
-   class ScheduleMaxException extends Exception {}
+   class MinimumParticipantNotMetException extends Exception {}
+
+   class ScheduleParticipantLimitExceededException extends Exception {}
 
    class ScheduleDateException extends Exception {}
+
+
 }

--- a/src/main/java/com/momo/momopjt/schedule/ScheduleServiceImpl.java
+++ b/src/main/java/com/momo/momopjt/schedule/ScheduleServiceImpl.java
@@ -3,6 +3,7 @@ package com.momo.momopjt.schedule;
 
 import com.momo.momopjt.alarm.AlarmService;
 import com.momo.momopjt.club.Club;
+import com.momo.momopjt.club.ClubRepository;
 import com.momo.momopjt.photo.PhotoService;
 import com.momo.momopjt.reply.ReplyDTO;
 import com.momo.momopjt.reply.ReplyService;
@@ -30,6 +31,7 @@ import java.util.stream.Collectors;
 public class ScheduleServiceImpl implements ScheduleService {
 
   private final ScheduleRepository scheduleRepository;
+  private final ClubRepository clubRepository;
 
   private final UserAndScheduleService userAndScheduleService;
   private final PhotoService photoService;
@@ -41,11 +43,18 @@ public class ScheduleServiceImpl implements ScheduleService {
 
   //일정 생성
   @Override
-  public Long createSchedule(ScheduleDTO scheduleDTO, UserAndScheduleDTO userAndScheduleDTO) throws ScheduleMaxException, ScheduleDateException {
+  public Long createSchedule(ScheduleDTO scheduleDTO, UserAndScheduleDTO userAndScheduleDTO) throws MinimumParticipantNotMetException, ScheduleDateException, ScheduleParticipantLimitExceededException {
+
+    //해당 모임 정원 확인
+    Long currentClubNo = scheduleDTO.getClubNo().getClubNo();
+    Club club = clubRepository.findById(currentClubNo).orElseThrow();
+    int clubMax = club.getClubMax();
 
     //일정 참가 수 검사 로직
     if (scheduleDTO.getScheduleMax() <= 0) {
-      throw new ScheduleMaxException();
+      throw new MinimumParticipantNotMetException();
+    }else if (scheduleDTO.getScheduleMax() > clubMax ) {
+      throw new ScheduleParticipantLimitExceededException();
     }
 
     //일정 시작 날짜 검사 로직


### PR DESCRIPTION
## 구현 기능

1. 등록한 참가 인원이 모임 전체 회원 수를 초과하면 예외가 발생하도록 구현하였습니다.
2. 참가 인원 초과 예외 발생 시 에러 메세지를 띄우고 일정 생성 페이지로 redirect하도록 구현