### PR TITLE
일정 생성/수정 시 검사 로직 공통 메서드로 분리

### DIFF
--- a/src/main/java/com/momo/momopjt/schedule/ScheduleController.java
+++ b/src/main/java/com/momo/momopjt/schedule/ScheduleController.java
@@ -103,6 +103,7 @@ public class ScheduleController {
     try {
       Long scheduleNo = scheduleService.createSchedule(scheduleDTO, userAndScheduleDTO);
       log.info("------------ [Succeed to set schedule] ------------");
+      redirectAttributes.addFlashAttribute("message", "일정이 정상적으로 등록되었습니다.");
       return "redirect:/schedule/" + scheduleNo;
     } catch (ScheduleService.ScheduleDateException e) {
       log.trace("------------ [Failed to set schedule: Attempted to set time in the past] ------------");
@@ -294,6 +295,7 @@ public class ScheduleController {
 
     try {
       Long updateScheduleNo = scheduleService.updateSchedule(scheduleDTO);
+      redirectAttributes.addFlashAttribute("message", "일정이 정상적으로 수정되었습니다.");
       return "redirect:/schedule/" + updateScheduleNo;
     }  catch (ScheduleService.ScheduleDateException e) {
       redirectAttributes.addFlashAttribute("message", "현재 시간보다 과거의 시간을 설정할 수 없습니다.");

--- a/src/main/java/com/momo/momopjt/schedule/ScheduleService.java
+++ b/src/main/java/com/momo/momopjt/schedule/ScheduleService.java
@@ -28,6 +28,8 @@ public interface ScheduleService {
 
    List<ScheduleDTO> readMyParticipatedSchedules(Club clubNo, User userNo);
 
+   void validateInfo (ScheduleDTO scheduleDTO, int participants) throws MinimumParticipantNotMetException, ScheduleDateException, ScheduleParticipantLimitExceededException;
+
    class MinimumParticipantNotMetException extends Exception {}
 
    class ScheduleParticipantLimitExceededException extends Exception {}


### PR DESCRIPTION
## 작업 사항
- 일정 생성/수정 시 중복되는 검사 로직을 validateScheduleData()로 분리하여 재사용성 개선

## 최소 인원 기준
- 일정 생성 시 최소 정원 기준을 0명으로 설정 (최초 등록되는 일정)
- 일정 수정 시 최소 정원을 현재 참석 인원 이상으로 설정 (기존 참석 인원 유지)
