### PR TITLE
일정 날짜/시간 타입을 Instant에서 LocalDateTime으로 변경

### DIFF
--- a/src/main/java/com/momo/momopjt/schedule/Schedule.java
+++ b/src/main/java/com/momo/momopjt/schedule/Schedule.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 import lombok.Setter;
 
 import javax.persistence.*;
-import java.time.Instant;
+import java.time.LocalDateTime;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
@@ -43,7 +43,7 @@ public class Schedule {
   private String schedulePlace;
 
   @Column(name = "schedule_start_date", nullable = false)
-  private Instant scheduleStartDate;
+  private LocalDateTime scheduleStartDate;
 
   @OneToMany(mappedBy = "scheduleNo")
   private Set<UserAndSchedule> userAndSchedules = new LinkedHashSet<>();

--- a/src/main/java/com/momo/momopjt/schedule/ScheduleController.java
+++ b/src/main/java/com/momo/momopjt/schedule/ScheduleController.java
@@ -85,9 +85,7 @@ public class ScheduleController {
     club.setClubNo(clubNo);
     scheduleDTO.setClubNo(club);
     LocalDateTime localDateTime = LocalDateTime.parse(dateTime);
-    ZonedDateTime zonedDateTime = localDateTime.atZone(ZoneId.systemDefault());
-    Instant instant = zonedDateTime.toInstant();
-    scheduleDTO.setScheduleStartDate(instant);
+    scheduleDTO.setScheduleStartDate(localDateTime);
     log.info("------------ [날짜/시간 포매팅 완료] ------------");
 
 
@@ -155,7 +153,7 @@ public class ScheduleController {
 
     int isParticipant = userAndScheduleService.isParticipate(userAndScheduleDTO);
 
-    model.addAttribute("currentTime", Instant.now());
+    model.addAttribute("currentTime", LocalDateTime.now());
     model.addAttribute("scheduleDTO", scheduleDTO); //일정 정보
     model.addAttribute("isScheduleFull", isScheduleFull); //일정인원 마감 여부
     model.addAttribute("userDTOList", userDTOList); //참가자 정보
@@ -232,17 +230,11 @@ public class ScheduleController {
     Long scheduleNo = (Long) session.getAttribute("scheduleNo");
     ScheduleDTO scheduleDTO = scheduleService.readOneSchedule(scheduleNo);
 
-    //날짜/시간 포매팅
-    Instant originStartDate = scheduleDTO.getScheduleStartDate();
-    ZonedDateTime zonedDate = originStartDate.atZone(ZoneId.systemDefault());
-    LocalDateTime formattedDate = zonedDate.toLocalDateTime();
-
     Long clubNo = (Long) session.getAttribute("clubNo");
     Club club = new Club();
     club.setClubNo(clubNo);
     int countMembers = userAndClubService.countMembers(club); //일정 수정 시 최대 참가 인원은 모임 전체 인원과 같음
     model.addAttribute("countMembers", countMembers);
-    model.addAttribute("scheduleStartDate", formattedDate);
     model.addAttribute("scheduleDTO", scheduleDTO);
     model.addAttribute("kakaoApiKey", kakaoApiKey);
 
@@ -269,9 +261,7 @@ public class ScheduleController {
     log.info("----------------- [session get scheduleNo]-----------------", scheduleNo);
     //날짜/시간 포매팅
     LocalDateTime localDateTime = LocalDateTime.parse(dateTime);
-    ZonedDateTime zonedDateTime = localDateTime.atZone(ZoneId.systemDefault());
-    Instant instant = zonedDateTime.toInstant();
-    scheduleDTO.setScheduleStartDate(instant);
+    scheduleDTO.setScheduleStartDate(localDateTime);
 
 //    사진 업데이트 준비 로직
     log.trace("update club photo 조회");

--- a/src/main/java/com/momo/momopjt/schedule/ScheduleDTO.java
+++ b/src/main/java/com/momo/momopjt/schedule/ScheduleDTO.java
@@ -6,7 +6,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import java.time.Instant;
+import java.time.LocalDateTime;
 
 
 @Data
@@ -32,6 +32,6 @@ public class ScheduleDTO {
 
   private String schedulePlace;
 
-  private Instant scheduleStartDate;
+  private LocalDateTime scheduleStartDate;
 
 }

--- a/src/main/java/com/momo/momopjt/schedule/ScheduleServiceImpl.java
+++ b/src/main/java/com/momo/momopjt/schedule/ScheduleServiceImpl.java
@@ -18,7 +18,7 @@ import org.springframework.stereotype.Service;
 
 
 import javax.transaction.Transactional;
-import java.time.Instant;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -296,7 +296,7 @@ public class ScheduleServiceImpl implements ScheduleService {
     }
 
     //일정 시작 날짜 검사 로직
-    if (scheduleDTO.getScheduleStartDate().isBefore(Instant.now())) {
+    if (scheduleDTO.getScheduleStartDate().isBefore(LocalDateTime.now())) {
       throw new ScheduleDateException();
     }
   }


### PR DESCRIPTION
## 작업 사항
- Entity와 DTO의 날짜/시간 필드 타입을 LocalDateTime으로 변경
- 불필요한 Instant 변환 및 시간대 정보 관련 로직 삭제

## 변경 이유
- 국내 서비스이므로 시간대 정보가 불필요하다고 판단
- 코드 복잡성 감소 및 가독성 향상